### PR TITLE
feat: add graphinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The first gate to enter the API Security Empire is to know how to gather informa
 - [FuzzDB](https://github.com/fuzzdb-project/fuzzdb)
 - [SoapUI](https://www.soapui.org/downloads/soapui/)
 - [GraphQL Voyager](https://apis.guru/graphql-voyager/)
+- [Graphinder](https://github.com/Escape-Technologies/graphinder)
 - [Kiterunner](https://github.com/assetnote/kiterunner)
 - [unfurl](https://github.com/tomnomnom/unfurl)
 


### PR DESCRIPTION
Hello, I propose to add Graphinder, which is a tool we created at https://escape.tech with my team in order to discover all GraphQL endpoints behind every subdomains of a domains.

You can find out more info here: https://blog.escape.tech/graphinder-lightweight-and-blazing-fast-graphql-endpoint-finder/

I think it is extremely useful to the recon phase and GraphQL Security ;) 

Best,

Antoine